### PR TITLE
LIVIJUKU-253

### DIFF
--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -11,6 +11,16 @@ global.window.afterEach = afterEach;
 
 global.navigator = window.navigator = {};
 
+/*
+ * Since angular and angular-mocks are both singletons created once with one window-object
+ * and mocha doesn't reload modules from node_modules on watch mode we'll have to invalidate the cached
+ * singletons manually.
+ */
+
+delete require.cache[require.resolve('angular')];
+delete require.cache[require.resolve('angular/angular')];
+delete require.cache[require.resolve('angular-mocks')];
+
 require('angular/angular');
 require('angular-mocks');
 


### PR DESCRIPTION
Poista angular-riippuvuudet requiren cachesta kun testit ajetaan uudelleen (--watch modessa)

* Angular ja angular-mocks on molemmat singletoneja jotka initialisoidaan kerran sen hetkiseen window - objektiin
* window-object luodaan kuitenkin joka kerta uudelleen kun testit ajetaan eikä mocha lataa uudelleen riippuvuuksia node_modules hakemistosta